### PR TITLE
fix: prevent unhandledPromiseRejection in getRepo

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const getRepo = (dir, cb) => {
   gitRemoteOriginUrl(dir).then(url => {
     repo = parseGitHubRepoUrl(url)
     cb(null, repo)
-  })
+  }).catch(cb)
 }
 
 const getBuilds = cb => {


### PR DESCRIPTION
If `gitRemoteOriginUrl` rejects, `cb` is called with rejection error. Will also be called if `cb` throws.